### PR TITLE
Add task item that checks docker is installed, read only task should not result in change

### DIFF
--- a/ansible/common/dev-env.yaml
+++ b/ansible/common/dev-env.yaml
@@ -18,6 +18,13 @@
     requirements: "{{playbook_dir}}/common/requirements-dev.txt"
     executable: pip3
 
+- name: Ensure that the docker is installed
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - docker
+
 - name: Ensure 'operator-sdk' is installed
   get_url:  
     url: "https://github.com/operator-framework/operator-sdk/releases/download/{{release}}/operator-sdk-{{release}}-x86_64-linux-gnu"

--- a/ansible/common/dev-env.yaml
+++ b/ansible/common/dev-env.yaml
@@ -36,6 +36,7 @@
 - name: "Ensure '{{GO_VERSION}}' is installed; Gather Facts"
   shell: "go version | grep -q {{GO_VERSION}}"
   register: go_version
+  changed_when: false
 
 - name: "Ensure '{{GO_VERSION}}' is installed; Install"
   unarchive:


### PR DESCRIPTION
Resolves #44 

* Add task to make sure docker is installed if it's not done via pip
* Add idempotency fix, checking for `go` should not invoke changes, read only process

On my test machine, I cloned my forked copy and switched branch: 
```
[root@c943f4n01-pvt ibm-spectrum-scale-csi-operator]# git branch
* master
[root@c943f4n01-pvt ibm-spectrum-scale-csi-operator]# git checkout docker_installed
Branch docker_installed set up to track remote branch docker_installed from origin.
Switched to a new branch 'docker_installed'
```

Testing if docker is already installed: 

```
[root@c943f4n01-pvt ibm-spectrum-scale-csi-operator]# rpm -qa | grep docker
docker-1.13.1-103.git7f2769b.el7.centos.x86_64
docker-client-1.13.1-103.git7f2769b.el7.centos.x86_64
docker-common-1.13.1-103.git7f2769b.el7.centos.x86_64
[root@c943f4n01-pvt ibm-spectrum-scale-csi-operator]# ansible-playbook $GOPATH/src/github.com/IBM/ibm-spectrum-scale-csi-operator/ansible/dev-env-playbook.yaml
.....

TASK [Ensure that the docker is installed] **************************************************************************************************
ok: [localhost] => (item=docker)

...


PLAY RECAP **********************************************************************************************************************************
localhost                  : ok=8    changed=1    unreachable=0    failed=0

[root@c943f4n01-pvt ibm-spectrum-scale-csi-operator]#
```

Run the  negative case....

Remove Docker...
```
[root@c943f4n01-pvt ibm-spectrum-scale-csi-operator]# yum -y remove docker*
[root@c943f4n01-pvt ibm-spectrum-scale-csi-operator]# rpm -qa | grep docker
[root@c943f4n01-pvt ibm-spectrum-scale-csi-operator]#
```

Run the playbook...
```
...
TASK [Ensure that the docker is installed] **************************************************************************************************
changed: [localhost] => (item=docker)

...
[root@c943f4n01-pvt ibm-spectrum-scale-csi-operator]# rpm -qa | grep docker
docker-common-1.13.1-103.git7f2769b.el7.centos.x86_64
docker-1.13.1-103.git7f2769b.el7.centos.x86_64
docker-client-1.13.1-103.git7f2769b.el7.centos.x86_64
[root@c943f4n01-pvt ibm-spectrum-scale-csi-operator]#
```

--------

The 2nd commit  is `changed_when: false` which identifies that there's really no change here, it's just gathering facts...

### Before

```
...
TASK [Ensure 'go1.13' is installed; Gather Facts] **************************************************************************
changed: [localhost]

TASK [Ensure 'go1.13' is installed; Install] *******************************************************************************
skipping: [localhost]

TASK [Expose Go to the global path] ****************************************************************************************
ok: [localhost]

PLAY RECAP *****************************************************************************************************************
localhost                  : ok=7    changed=1    unreachable=0    failed=0
```
So `changed=1` summary, when really nothing changed....

### After
```
TASK [Ensure 'go1.13' is installed; Gather Facts] *******************************************************************************************
ok: [localhost]

TASK [Ensure 'go1.13' is installed; Install] ************************************************************************************************
skipping: [localhost]

TASK [Expose Go to the global path] *********************************************************************************************************
ok: [localhost]

PLAY RECAP **********************************************************************************************************************************
localhost                  : ok=8    changed=0    unreachable=0    failed=0

```


I think the ansible-lint would have caught this one. 