### PR TITLE
Some changes to the main README.md file to help streamline the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ hacks/change_deploy_image.py -i quay.io/<your-user>/ibm-spectrum-scale-csi-opera
 
 ## Deploying the Operator
 
->**WARNING** If you are using your own image you must, complete (#using-the-image)!
+> **WARNING** If you are using your own image you must, complete [using the image](#using-the-image)!
 
 ### Option A: Manually
 

--- a/README.md
+++ b/README.md
@@ -54,22 +54,33 @@ operator-sdk build csi-scale-operator
 >**NOTE** This requires `docker`.
 
 ### Using the image
->**NOTE** If you're using the quay image, this step can be skipped.
 
-In order to use the image in your environment you will need to push the image to a [docker registry](https://docs.docker.com/registry/). You may setup your own image, or push to a repository such  as [quay.io](quay.io).
+In order to use the images that you just built, the image needs to be pushed to some container repository.
 
-Deploying your own registry is an [involved process](https://docs.docker.com/registry/deploying/), and outside of the scope of this document. 
+* **Quay.io (recommended)**
 
-If you're using quay, we recommend doing the [Quay Tutorial](https://quay.io/tutorial/).
+  Follow this tutorial to configure [quay.io](https://quay.io/tutorial/) and then create a repository named: `ibm-spectrum-scale-csi-operator`.
 
+* **Docker** 
 
-Once you have a repository ready and you've logged you can tag and push your image:
+  Deploying your own Docker registry is an [involved process](https://docs.docker.com/registry/deploying/), and outside of the scope of this document. 
+
+The documentation will assume that the quay.io path is being used. 
+
+Once you have a repository ready:
+
 ``` bash
-docker tag csi-scale-operator <your-repo>/ibm-spectrum-scale-csi-operator:v0.9.1
-docker push <your-repo>/ibm-spectrum-scale-csi-operator:v0.9.1
+# Authenticate to quay.io
+docker login <credentials>  quay.io
 
-# This will update your deployment to point at your image.
-hacks/change_deploy_image.py -i <your-repo>/ibm-spectrum-scale-csi-operator:v0.9.1
+# Tag the build 
+docker tag csi-scale-operator quay.io/<your-user>/ibm-spectrum-scale-csi-operator:v0.9.1
+
+# push the image
+docker push quay.io/<your-user>/ibm-spectrum-scale-csi-operator:v0.9.1
+
+# Update your deployment to point at your image.
+hacks/change_deploy_image.py -i quay.io/<your-user>/ibm-spectrum-scale-csi-operator:v0.9.1
 ```
 
 ## Deploying the Operator

--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@ An Ansible based operator to run and manage the deployment of the
 
 This project was originally generated using [operator-sdk](https://github.com/operator-framework/operator-sdk).
 
-> **WARNING** : This repository undergoing active development! If you encounter issues with any of the following 
-> instructions, [_please open an issue_](https://github.com/IBM/ibm-spectrum-scale-csi-operator/issues).
+> **WARNING**: This repository undergoing active development! If you encounter issues with the following instructions, [_please open an issue_](https://github.com/IBM/ibm-spectrum-scale-csi-operator/issues).
 
 ## Setup from scratch
+
 ### Cloning the repository
 
->**WARNING** : This repository needs to be accessible in your `GOPATH`. In the development environment this was set to `/root/go`, however this is at the discretion of the user.
+> **WARNING**: This repository needs to be accessible in your `GOPATH`. In testing, the root user was used and set to: `GOPATH=/root/go`.
 
-Due to constraints in golang (relative paths are not supported in golang) you **_MUST_** clone this repository to the IBM directory in your go path. If this is not done, the `operator-sdk` build operation will fail.
+> **NOTE**: Due to current constraints in golang (relative paths are not supported in golang), you **_MUST_** clone this repository under your gopath. If not, the `operator-sdk` build operation will fail.
 
 ``` bash
 # Set up some helpful variables
-export GOPATH=<your-go-path>
+export GOPATH="/root/go"
 export IBM_DIR="$GOPATH/src/github.com/IBM"
 export OPERATOR_DIR="$IBM_DIR/ibm-spectrum-scale-csi-operator"
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ This project was originally generated using [operator-sdk](https://github.com/op
 # Set up some helpful variables
 export GOPATH="/root/go"
 export IBM_DIR="$GOPATH/src/github.com/IBM"
-export OPERATOR_DIR="$IBM_DIR/ibm-spectrum-scale-csi-operator"
 
 # Ensure the dir is present then clone.
 mkdir -p ${IBM_DIR}
@@ -44,11 +43,12 @@ ansible-playbook $GOPATH/src/github.com/IBM/ibm-spectrum-scale-csi-operator/ansi
 To build the image the user must navigate to the operator directory (This directory structure is an artifact of the IBM Cloud Pak certification process). 
 
 ``` bash
-cd stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator
+# IBM_DIR is defined in the previous step
+export OPERATOR_DIR="$IBM_DIR/ibm-spectrum-scale-csi-operator"
+cd ${OPERATOR_DIR}/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator
+
 export GO111MODULE="on"
 operator-sdk build csi-scale-operator
-
-docker tag csi-scale-operator quay.io/mew2057/ibm-spectrum-scale-csi-operator:v0.9.1
 ```
 
 >**NOTE** This requires `docker`.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Once you have a repository ready:
 
 ``` bash
 # Authenticate to quay.io
-docker login <credentials>  quay.io
+docker login <credentials> quay.io
 
 # Tag the build 
 docker tag csi-scale-operator quay.io/<your-user>/ibm-spectrum-scale-csi-operator:v0.9.1
@@ -89,8 +89,6 @@ hacks/change_deploy_image.py -i quay.io/<your-user>/ibm-spectrum-scale-csi-opera
 
 ### Option A: Manually
 
-> **NOTE**: Kubernetes use `kubectl` command, replace with `oc` if deploying in OpenShift.
-
 If you've built the image as outlined above and tagged it, you can easily run the following to deploy the operator manually:
 
 ``` bash
@@ -102,40 +100,42 @@ kubectl apply -f deploy/crds/ibm_v1alpha1_csiscaleoperator_crd.yaml
 kubectl apply -f deploy/operator.yaml
 ```
 
+> **NOTE**: Kubernetes use `kubectl` command, replace with `oc` if deploying in OpenShift.
+
 At this point the operator is running and ready for use!
 
 ### Option B: Using OLM
 
 > **NOTE**: This will be the prefered method.  However, work is ongoing.
 
-> **NOTE**: Kubernetes use `kubectl` command, replace with `oc` if deploying in OpenShift.
-
 The following will subscribe the [quay.io](quay.io) version of the operator assuming OLM is installed.
 
 ``` bash
 kubectl apply -f deploy/olm-test/operator-source.yaml
 ```
+> **NOTE**: Kubernetes use `kubectl` command, replace with `oc` if deploying in OpenShift.
+
 
 ## Starting the CSI Driver
 
 Once the operator is running the user needs to access the operator's API and request a deployment. This is done through use of the `CSIScaleOperator` Custom Resource. 
 
-Before starting the pluging, add any secrets to the appropriate namespace, the Spectrum Scale namespace is `ibm-spectrum-scale-csi-driver`:
+> **ATTENTION** : If the driver pod does not start, it is generally due to missing secrets. 
+
+Before starting the plugin, add any secrets to the appropriate namespace.  The Spectrum Scale namespace is `ibm-spectrum-scale-csi-driver`:
 
 ``` bash
 kubectl apply -f secrets.yaml -n ibm-spectrum-scale-csi-driver
 ```
 
-> **ATTENTION** : If the driver pod does not start, it is generally due to missing secrets. 
+A sample of the file is provided [examples/spectrum_scale.yaml](stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/example/spectrum_scale.yaml). 
 
-A sample of the file is provided [examples/spectrum_scale.yaml](stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/example/spectrum_scale.yaml). Modify this file to match the properties in your environment, then:
+Modify this file to match the properties in your environment, then:
 
-  * To start the CSI plugin run: `kubectl apply -f spectrum_scale.yaml` 
+  * To start the CSI plugin, run: `kubectl apply -f spectrum_scale.yaml` 
   * To stop the CSI plugin, run: `kubectl delete -f spectrum_scale.yaml` 
 
 ## Uninstalling the CSI Operator
-
-> **NOTE**: Kubernetes use `kubectl` command, replace with `oc` if deploying in OpenShift.
 
 To remove the operator:
 
@@ -149,6 +149,8 @@ kubectl delete -f deploy/crds/ibm_v1alpha1_csiscaleoperator_crd.yaml
 kubectl delete -f deploy/namespace.yaml
 ```
 
-Please note, this will completely destroy the operator and all associated resources.
+> **NOTE**: Kubernetes use `kubectl` command, replace with `oc` if deploying in OpenShift.
+
+This will completely destroy the operator and all associated resources.
 
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ hacks/change_deploy_image.py -i quay.io/<your-user>/ibm-spectrum-scale-csi-opera
 If you've built the image as outlined above and tagged it, you can easily run the following to deploy the operator manually:
 
 ``` bash
+cd ${OPERATOR_DIR}/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator
+
 kubectl apply -f deploy/namespace.yaml
 kubectl apply -f deploy/service_account.yaml
 kubectl apply -f deploy/role.yaml
@@ -111,7 +113,9 @@ At this point the operator is running and ready for use!
 The following will subscribe the [quay.io](quay.io) version of the operator assuming OLM is installed.
 
 ``` bash
-kubectl apply -f deploy/olm-test/operator-source.yaml
+cd ${OPERATOR_DIR}/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator
+
+kubectl apply -f deploy/olm-scripts/operator-source.yaml
 ```
 > **NOTE**: Kubernetes use `kubectl` command, replace with `oc` if deploying in OpenShift.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ kubectl apply -f deploy/operator.yaml
 
 At this point the operator is running and ready for use!
 
-### Option B: Using OLM
+### Option B: Using Operator Lifecycle Manager (OLM)
 
 > **NOTE**: This will be the prefered method.  However, work is ongoing.
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,6 @@ cd ${IBM_DIR}
 git clone https://github.com/IBM/ibm-spectrum-scale-csi-operator.git
 ```
 
-If you are working out of a forked copy you can change your origin to match:
-
-``` bash
-git remote set-url origin <forked git repo>
-git remote add upstream git@github.com:IBM/ibm-spectrum-scale-csi-operator.git
-
-git pull origin
-```
-
 ### Development environment setup
 
 The development environment dependencies are managed using an ansible playbook for the IBM Spectrum Scale CSI Operator. If ansible is installed in your environment simply run the following command:

--- a/README.md
+++ b/README.md
@@ -33,18 +33,11 @@ git clone https://github.com/IBM/ibm-spectrum-scale-csi-operator.git
 
 ### Development environment setup
 
-The development environment dependencies are managed using an ansible playbook for the IBM Spectrum Scale CSI Operator. If ansible is installed in your environment simply run the following command:
+To help configure and resolve dependencies to build the csi-operator, a ansible playbook is provided.  You can run the following to invoke the playbook:
 
 ``` bash
 ansible-playbook $GOPATH/src/github.com/IBM/ibm-spectrum-scale-csi-operator/ansible/dev-env-playbook.yaml
 ```
-
-This script will do the following:
-1. Install `python3`
-2. Install `python3` requirements (`sphinx`, `operator-courier`, `docker`)
-3. Install `operator-sdk`
-4. Ensure `go-1.13` is installed.
-
 
 ### Building the image
 

--- a/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/example/spectrum_scale.yaml
+++ b/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/example/spectrum_scale.yaml
@@ -54,5 +54,4 @@ spec:
 
           # The port number running the REST server.
           # guiPort
-
   # ----

--- a/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/example/spectrum_scale.yaml
+++ b/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/example/spectrum_scale.yaml
@@ -7,20 +7,6 @@ metadata:
     namespace: ibm-spectrum-scale-csi-driver
 status: {}
 spec:
-  # ----
-  # Attacher image for csi (actually attaches to the storage).
-  attacher: "quay.io/k8scsi/csi-attacher:v1.0.0"
-
-  # Provisioner image for csi (actually issues provision requests).
-  provisioner: "quay.io/k8scsi/csi-provisioner:v1.0.0"
-
-  # Sidecar container image for the csi spectrum scale plugin pods.
-  driverRegistrar: "quay.io/k8scsi/csi-node-driver-registrar:v1.0.1"
-
-  # Image name for the csi spectrum scale plugin container.
-  spectrumScale: "quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v0.9.1"
-  # ----
-
   # Required
   # ----
   # The path to the gpfs file system mounted on the host machine.

--- a/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/example/spectrum_scale.yaml
+++ b/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/example/spectrum_scale.yaml
@@ -1,22 +1,58 @@
+# spectrum_scale.yaml
 apiVersion: scale.ibm.com/v1alpha1
 kind: 'CSIScaleOperator'
-metadata: 
+metadata:
     # IMPORTANT THE OPERATOR LOOKS FOR THIS!
     name: 'ibm-spectrum-scale-csi'
     namespace: ibm-spectrum-scale-csi-driver
 status: {}
-spec: 
-  # 
-  scaleHostpath: "/ibm/fs1"
+spec:
+  # ----
+  # Attacher image for csi (actually attaches to the storage).
+  attacher: "quay.io/k8scsi/csi-attacher:v1.0.0"
 
-  clusters: 
-    - id: "11832033572270148010"
-      secrets: "secret1"
+  # Provisioner image for csi (actually issues provision requests).
+  provisioner: "quay.io/k8scsi/csi-provisioner:v1.0.0"
+
+  # Sidecar container image for the csi spectrum scale plugin pods.
+  driverRegistrar: "quay.io/k8scsi/csi-node-driver-registrar:v1.0.1"
+
+  # Image name for the csi spectrum scale plugin container.
+  spectrumScale: "quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v0.9.1"
+  # ----
+
+  # Required
+  # ----
+  # The path to the gpfs file system mounted on the host machine.
+  scaleHostpath: "<REPLACE ME>"
+
+  # A collection of gpfs cluster properties for the csi driver to mount.
+  clusters:
+    # The cluster id of the gpfs cluster specified (mandatory).
+    - id: "<REPLACE ME>"
+
+      # A string specifying a secret resource name.
+      secrets: "<REPLACE ME>"
+
+      # Require a secure SSL connection to connect to GPFS.
       secureSslMode: false
+
+      # A string specifying a cacert resource name.
+      # cacert: <>
+
+      # The primary file system for the GPFS cluster
       primary:
-        primaryFs: "fs1"
-        primaryFset: "csiFset2"
-      restApi: 
-      - guiHost: "jdunham-rh72-k8s-scale-master.fyre.ibm.com"
+        # The name of the primary filesystem.
+        primaryFS: "<REPLACE ME>"
+        # The name of the primary fileset, created in primaryFS.
+        primaryFset: "<REPLACE ME>"
 
+      # A collection of targets for REST calls.
+      restApi:
+        # The hostname of the REST server.
+        - guiHost: "<REPLACE ME>"
 
+          # The port number running the REST server.
+          # guiPort
+
+  # ----


### PR DESCRIPTION
To partially address #45 

Based on my running of the operator deployment  in my  OpenShift Environment.  These instructions are really to
* simplify the steps 
* allow for more copy/paste solution
* temporarily bridge the gap we have until the OLM method is working 

Once that is in place, the documentation for this repo should really be written towards a  developer that  wants to make changes to the operator and contribute to the  project, not a IBM Spectrum Scale end user. 

I do also want more details to be documented in RTD, but that effort is getting quite  large,  so I wanted to address these changes. 

