### PR TITLE
Changing GUIPort type to integer.

### DIFF
--- a/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/crds/ibm_v1alpha1_csiscaleoperator_crd.yaml
+++ b/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/crds/ibm_v1alpha1_csiscaleoperator_crd.yaml
@@ -161,7 +161,7 @@ spec:
 
                         guiPort:
                           description: The port number running the REST server.
-                          type: string
+                          type: integer
 
                   secrets:
                     description: A string specifying a secret resource name.

--- a/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/0.9.1/ibm_v1alpha1_csiscaleoperator_crd.yaml
+++ b/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/0.9.1/ibm_v1alpha1_csiscaleoperator_crd.yaml
@@ -161,7 +161,7 @@ spec:
 
                         guiPort:
                           description: The port number running the REST server.
-                          type: string
+                          type: integer
 
                   secrets:
                     description: A string specifying a secret resource name.

--- a/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/0.9.2/ibm_v1alpha1_csiscaleoperator_crd.yaml
+++ b/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/0.9.2/ibm_v1alpha1_csiscaleoperator_crd.yaml
@@ -161,7 +161,7 @@ spec:
 
                         guiPort:
                           description: The port number running the REST server.
-                          type: string
+                          type: integer
 
                   secrets:
                     description: A string specifying a secret resource name.


### PR DESCRIPTION
```
E1122 20:41:41.829929       1 scale_config.go:114] Error in unmarshalling Spectrum Scale configuration json: json: cannot unmarshal string into Go struct field RestAPI.Clusters.restApi.guiPort of type int
I1122 20:41:41.829970       1 gpfs.go:428] gpfs ValidateScal

```