### PR TITLE
Clearing Whitespace from end of README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,5 +205,3 @@ NAMESPACE=ibm-spectrum-scale-csi-driver
 kubectl delete -n $NAMESPACE $POD_NAME
 ```
 
-
-


### PR DESCRIPTION
I made a mistake and edited the README from github, this PR is to fix the failure that the code is now showing.