### PR TITLE
Proposing this script to have a consistent way to generate release tar files to upload to GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ build/_test
 .DS_Store
 # Travis Validation Files
 generated/installer/*.test.yaml
+# Tools 
+tools/ibm-spectrum-scale-csi-operator*
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/docs/source/deployment/manual.rst
+++ b/docs/source/deployment/manual.rst
@@ -7,35 +7,32 @@ The following ``.yaml`` files needs to be applied to your cluster
 
 
 namespace.yaml
-    This configuration file creates the ``ibm-spectrum-scale-csi-driver`` namespace
+    This configuration file creates the ``ibm-spectrum-scale-csi-driver`` namespace.
 
 ibm-spectrum-scale-csi-operator.yaml
-    This is an auto-generated combined configuration file that starts the operator.
+    This is an auto-generated combined configuration file that starts the operator pods.
 
 ibm-spectrum-scale-csi-operator-cr.yaml
-    This is a custom resource file (CR) that the admin must modify to match their Spectrum Scale install, which loads the csi-driver plugin.
+    This is a custom resource file (CR) that the admin must modify to match their Spectrum Scale environment, which loads the csi-driver plugin.
 
 
-1. Download the ``.yaml`` files from the code repository
+Create the Operator
+===================
 
-.. code-block:: bash
-
-    curl -O https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-csi-operator/master/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/namespace.yaml
-    curl -O https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-csi-operator/master/generated/installer/ibm-spectrum-scale-csi-operator.yaml
-    curl -O https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-csi-operator/master/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/crds/ibm-spectrum-scale-csi-operator-cr.yaml
+1. Download and extract a ``.tar.gz`` file from `ibm-spectrum-scale-csi-operator/releases <https://github.com/IBM/ibm-spectrum-scale-csi-operator/releases/>`_ page.
 
 2. Apply the namespace and operator configuration files.
 
-.. code-block:: bash
+  .. code-block:: bash
 
-    kubectl apply -f namespace.yaml
-    kubectl apply -f ibm-spectrum-scale-csi-operator.yaml
+      kubectl apply -f namespace.yaml
+      kubectl apply -f ibm-spectrum-scale-csi-operator.yaml
 
 3. Create and apply the secret for the Spectrum Scale GUI.
 
-Create a file ``secret.json`` with the following, replacing the ``name|username|password`` fields. 
+  Create a file ``secret.json`` with the following, replacing the ``name|username|password`` fields. 
 
-.. code-block:: json
+  .. code-block:: json
     
     {
         "apiVersion": "v1",
@@ -45,27 +42,38 @@ Create a file ``secret.json`` with the following, replacing the ``name|username|
             "kind": "Secret",
             "apiVersion": "v1",
             "metadata": {
-                "name": "{{ gui_secret_name }}",
+                "name": "<spectrum-scale-gui-secret>",
                 "label": {
                     "app.kubernetes.io/name": "ibm-spectrum-scale-csi-operator"
                 }
             },
             "data": {
-                "username": "{{ gui_user | b64encode }}",
-                "password": "{{ gui_pass | b64encode }}"
+                "username": "<base64_username>",
+                "password": "<base64_password>"
             }
         }]
     }
 
-Then apply with the following command:
+  Then apply with the following command:
 
-.. code-block:: bash
+  .. code-block:: bash
 
     kubectl apply -f secret.json 
 
 4. Edit and apply the ``ibm-spectrum-scale-csi-operator-cr.yaml`` file to start the csi-driver plugin.
 
-.. code-block:: bash
+  .. code-block:: bash
 
     # Modify this file to match your environment properties
     kubectl apply -f ibm-spectrum-scale-csi-operator-cr.yaml
+
+Delete the Operator 
+===================
+
+1. To remove the operator, run ``delete`` of the yaml files in the following order: 
+
+  .. code-block:: bash
+
+      kubectl delete -f ibm-spectrum-scale-csi-operator-cr.yaml
+      kubectl delete -f ibm-spectrum-scale-csi-operator.yaml
+      kubectl delete -f namespace.yaml

--- a/tools/create_release_tar.sh
+++ b/tools/create_release_tar.sh
@@ -58,7 +58,7 @@ cd -
 #
 # Tar up and clean up working files 
 echo "Tar up files ..."
-tar cfvj ${TAR_FILE} ./${TMP_DIR}
+tar -czvf ${TAR_FILE} ./${TMP_DIR}
 echo "Cleanup ${TMP_DIR} ..."
 rm -rf ${TMP_DIR}
 

--- a/tools/create_release_tar.sh
+++ b/tools/create_release_tar.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# While not recommended, you can pass in the version instead of being on the tagged/branch
+#
+# Usage: ./create_release_tar.sh
+#        ./create_release_tar.sh v1.0.0   # Not recommended
+#
+# 
+
+if [[ `which md5sum >> /dev/null; echo $?` != 0 ]]; then
+   echo "ERROR, this script requires md5sum."
+   exit 1
+fi
+
+FILES=( './stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/namespace.yaml'
+'./generated/installer//ibm-spectrum-scale-csi-operator.yaml'
+'./stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/crds/ibm-spectrum-scale-csi-operator-cr.yaml'
+)
+
+TOPLEVEL=`git rev-parse --show-toplevel`
+
+echo $TOPLEVEL
+
+PROJ_NAME=`basename $TOPLEVEL`
+if [[ -z ${1} ]]; then
+   TAG_NAME=`git symbolic-ref -q --short HEAD || git describe --tags --exact-match` 
+else
+   TAG_NAME=${1}
+fi
+
+TAR_FILE="$PROJ_NAME-$TAG_NAME.tar.gz"
+TMP_DIR="$PROJ_NAME.${TAG_NAME}"
+
+echo "DEBUG: PROJ_NAME . . : $PROJ_NAME"
+echo "DEBUG: TAG_NAME . . .: $TAG_NAME"
+echo "DEBUG: TAR_FILE . . .: $TAR_FILE"
+
+
+echo "Creating ${TMP_DIR} ..."
+mkdir -p ${TMP_DIR}
+
+echo "Copying yaml files to ${TMP_DIR} ..."
+for f in ${FILES[*]}; do 
+   cp $TOPLEVEL/$f ${TMP_DIR}/
+done
+cd ${TMP_DIR}
+md5sum * >> md5sum
+cd -
+
+
+
+echo "Tar up files ..."
+tar cfvj $TAR_FILE ./${TMP_DIR}
+echo "Cleanup ${TMP_DIR} ..."
+# rm -rf ${TMP_DIR}
+
+echo "====== Generated Files ======="
+ls -ltr ${TAR_FILE}
+sum ${TAR_FILE}
+
+

--- a/tools/create_release_tar.sh
+++ b/tools/create_release_tar.sh
@@ -18,30 +18,35 @@ FILES=( './stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-
 )
 
 TOPLEVEL=`git rev-parse --show-toplevel`
+echo ${TOPLEVEL}
 
-echo $TOPLEVEL
-
-PROJ_NAME=`basename $TOPLEVEL`
+PROJ_NAME=`basename ${TOPLEVEL}`
 if [[ -z ${1} ]]; then
-   TAG_NAME=`git symbolic-ref -q --short HEAD || git describe --tags --exact-match` 
+   TAG_NAME=`git describe || git describe --tags --exact-match`
 else
    TAG_NAME=${1}
 fi
 
-TAR_FILE="$PROJ_NAME-$TAG_NAME.tar.gz"
-TMP_DIR="$PROJ_NAME.${TAG_NAME}"
+if [[ -z ${TAG_NAME} ]]; then
+   echo "ERROR, could not determine the tag name, cannot continue."
+   exit 1
+fi
 
-echo "DEBUG: PROJ_NAME . . : $PROJ_NAME"
-echo "DEBUG: TAG_NAME . . .: $TAG_NAME"
-echo "DEBUG: TAR_FILE . . .: $TAR_FILE"
+TARGET_NAME="${PROJ_NAME}-${TAG_NAME}"
 
+echo "DEBUG: PROJ_NAME . . : ${PROJ_NAME}"
+echo "DEBUG: TAG_NAME . . .: ${TAG_NAME}"
+echo "DEBUG: TARGET_NAME  .: ${TARGET_NAME}"
+
+TAR_FILE="${TARGET_NAME}.tar.gz"
+TMP_DIR="${TARGET_NAME}"
 
 echo "Creating ${TMP_DIR} ..."
 mkdir -p ${TMP_DIR}
 
 echo "Copying yaml files to ${TMP_DIR} ..."
 for f in ${FILES[*]}; do 
-   cp $TOPLEVEL/$f ${TMP_DIR}/
+   cp ${TOPLEVEL}/${f} ${TMP_DIR}/
 done
 cd ${TMP_DIR}
 md5sum * >> md5sum
@@ -50,7 +55,7 @@ cd -
 
 
 echo "Tar up files ..."
-tar cfvj $TAR_FILE ./${TMP_DIR}
+tar cfvj ${TAR_FILE} ./${TMP_DIR}
 echo "Cleanup ${TMP_DIR} ..."
 # rm -rf ${TMP_DIR}
 

--- a/tools/create_release_tar.sh
+++ b/tools/create_release_tar.sh
@@ -22,7 +22,7 @@ echo ${TOPLEVEL}
 
 PROJ_NAME=`basename ${TOPLEVEL}`
 if [[ -z ${1} ]]; then
-   TAG_NAME=`git describe || git describe --tags --exact-match`
+   TAG_NAME=`git describe --tags --exact-match || git describe`
 else
    TAG_NAME=${1}
 fi

--- a/tools/create_release_tar.sh
+++ b/tools/create_release_tar.sh
@@ -48,16 +48,19 @@ echo "Copying yaml files to ${TMP_DIR} ..."
 for f in ${FILES[*]}; do 
    cp ${TOPLEVEL}/${f} ${TMP_DIR}/
 done
+
+# Create the md5sum for the yaml files 
+#
 cd ${TMP_DIR}
 md5sum * >> md5sum
 cd -
 
-
-
+#
+# Tar up and clean up working files 
 echo "Tar up files ..."
 tar cfvj ${TAR_FILE} ./${TMP_DIR}
 echo "Cleanup ${TMP_DIR} ..."
-# rm -rf ${TMP_DIR}
+rm -rf ${TMP_DIR}
 
 echo "====== Generated Files ======="
 ls -ltr ${TAR_FILE}


### PR DESCRIPTION
Not sure if we want to do this yet, but  I created this script so might as well propose it.  The script can be executed in the tools directory,  and it will create a tar.gz file that we can then upload to GitHub Releases. 

The tar files and temporary directories are in the format `ibm-spectrum-scale-csi-operator*`, so I've added an entry in `.gitignore`.  We do not want to check in this file/directory, just upload the release tar to GitHub. 

The idea here is after we tag for release, we would then `git checkout <tag>` and run this script.  Here's some examples:

```
[vhu@c943mn01 tools]$ git  branch
  dev
* generate_release_tar
  master
[vhu@c943mn01 tools]$ ./create_release_tar.sh
/gsa/pokgsa-h2/08/vhu/GitHub/forked/ibm-spectrum-scale-csi-operator
fatal: no tag exactly matches 'ea29e531e8fdb195d7c1e5a6139e7e0f3c04d1c6'
DEBUG: PROJ_NAME . . : ibm-spectrum-scale-csi-operator
DEBUG: TAG_NAME . . .: v0.9.0-238-gea29e53
DEBUG: TARGET_NAME  .: ibm-spectrum-scale-csi-operator-v0.9.0-238-gea29e53
Creating ibm-spectrum-scale-csi-operator-v0.9.0-238-gea29e53 ...
Copying yaml files to ibm-spectrum-scale-csi-operator-v0.9.0-238-gea29e53 ...
/gsa/pokgsa/home/v/h/vhu/GitHub/forked/ibm-spectrum-scale-csi-operator/tools
Tar up files ...
./ibm-spectrum-scale-csi-operator-v0.9.0-238-gea29e53/
./ibm-spectrum-scale-csi-operator-v0.9.0-238-gea29e53/ibm-spectrum-scale-csi-operator.yaml
./ibm-spectrum-scale-csi-operator-v0.9.0-238-gea29e53/namespace.yaml
./ibm-spectrum-scale-csi-operator-v0.9.0-238-gea29e53/md5sum
./ibm-spectrum-scale-csi-operator-v0.9.0-238-gea29e53/ibm-spectrum-scale-csi-operator-cr.yaml
Cleanup ibm-spectrum-scale-csi-operator-v0.9.0-238-gea29e53 ...
====== Generated Files =======
-rw-rw-r-- 1 vhu vhu 4067 Dec  6 14:07 ibm-spectrum-scale-csi-operator-v0.9.0-238-gea29e53.tar.gz
34650     4
[vhu@c943mn01 tools]$
```

Because  I'm not in a tag that matches exactly...  it's going to take `git describe` from the last known tag, which is `v0.9.0` on my clone.   This creates unique-ness in the tar files that we create.

Copy the script (because it won't be in the upstream project and checking out a will delete it) 

```
[vhu@c943mn01 tools]$ cp create_release_tar.sh create_release_tar2.sh
```

Let's get the v1.0.0 tag..
```
[vhu@c943mn01 tools]$ git fetch --all
Fetching origin
Fetching upstream
From https://github.com/IBM/ibm-spectrum-scale-csi-operator
   7ebf002..129fa1c  dev        -> upstream/dev
   a96dd6a..67535f3  master     -> upstream/master
 * [new tag]         v1.0.0     -> v1.0.0
[vhu@c943mn01 tools]$
```

Now running it here: 

```
[vhu@c943mn01 tools]$ git checkout v1.0.0
Note: checking out 'v1.0.0'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 8682e20... Merge pull request #92 from IBM/dev
[vhu@c943mn01 tools]$ ./create_release_tar2.sh
/gsa/pokgsa-h2/08/vhu/GitHub/forked/ibm-spectrum-scale-csi-operator
DEBUG: PROJ_NAME . . : ibm-spectrum-scale-csi-operator
DEBUG: TAG_NAME . . .: v1.0.0
DEBUG: TARGET_NAME  .: ibm-spectrum-scale-csi-operator-v1.0.0
Creating ibm-spectrum-scale-csi-operator-v1.0.0 ...
Copying yaml files to ibm-spectrum-scale-csi-operator-v1.0.0 ...
/gsa/pokgsa/home/v/h/vhu/GitHub/forked/ibm-spectrum-scale-csi-operator/tools
Tar up files ...
./ibm-spectrum-scale-csi-operator-v1.0.0/
./ibm-spectrum-scale-csi-operator-v1.0.0/ibm-spectrum-scale-csi-operator.yaml
./ibm-spectrum-scale-csi-operator-v1.0.0/namespace.yaml
./ibm-spectrum-scale-csi-operator-v1.0.0/md5sum
./ibm-spectrum-scale-csi-operator-v1.0.0/ibm-spectrum-scale-csi-operator-cr.yaml
Cleanup ibm-spectrum-scale-csi-operator-v1.0.0 ...
====== Generated Files =======
-rw-rw-r-- 1 vhu vhu 4034 Dec  6 14:09 ibm-spectrum-scale-csi-operator-v1.0.0.tar.gz
57679     4
[vhu@c943mn01 tools]$
```