### PR TITLE
The OperatorHub display names for Driver in not consistent with the product names [ DO NOT MERGE ]

### DIFF
--- a/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.0.0/ibm-spectrum-scale-csi-operator.v1.0.0.clusterserviceversion.yaml
+++ b/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.0.0/ibm-spectrum-scale-csi-operator.v1.0.0.clusterserviceversion.yaml
@@ -68,7 +68,7 @@ spec:
         path: provisionerNodeSelector
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: Node selector for SpectrumScale CSI Plugin.
+      - description: Node selector for Spectrum Scale CSI Plugin.
         displayName: Plugin Node Selector
         path: pluginNodeSelector
         x-descriptors:
@@ -79,7 +79,7 @@ spec:
         path: clusters
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: Image name for the csi spectrum scale plugin container.
+      - description: Image name for the Spectrum Scale CSI plugin container.
         displayName: Spectrum Scale Image
         path: spectrumScale
         x-descriptors:
@@ -90,17 +90,17 @@ spec:
         path: secretCounter
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: Mapping of K8s node with SpectrumScale node.
+      - description: Mapping of K8s node with Spectrum Scale node.
         displayName: nodeMapping
         path: nodeMapping
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:label
-      - description: Provisioner image for csi (actually issues provision requests).
+      - description: Provisioner image for CSI (actually issues provision requests).
         displayName: Provisioner Image
         path: provisioner
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:label
-      - description: Sidecar container image for the csi spectrum scale plugin pods.
+      - description: Sidecar container image for the Spectrum Scale CSI plugin pods.
         displayName: Driver Registrar Image
         path: driverRegistrar
         x-descriptors:
@@ -110,7 +110,7 @@ spec:
         path: scaleHostpath
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:label
-      - description: Attacher image for csi (actually attaches to the storage).
+      - description: Attacher image for CSI (actually attaches to the storage).
         displayName: Attacher Image
         path: attacher
         x-descriptors:
@@ -175,7 +175,7 @@ spec:
         path: nodeMapping.k8sNode
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:label
-      - description: SpectrumScale node name.
+      - description: Spectrum Scale node name.
         displayName: Spectrum Scale Node
         path: nodeMapping.spectrumscaleNode
         x-descriptors:

--- a/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.0.0/ibm-spectrum-scale-csi-operator.v1.0.0.clusterserviceversion.yaml
+++ b/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.0.0/ibm-spectrum-scale-csi-operator.v1.0.0.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     certified: 'false'
     containerImage: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-operator:v1.0.0
     createdAt: Wed Dec  4 06:41:31 EST 2019
-    description: An operator for deploying and managing the IBM CSI Spectrum Scale Driver.
+    description: An operator for deploying and managing the IBM Spectrum Scale CSI Driver.
     repository: https://github.com/IBM/ibm-spectrum-scale-csi-operator/
     support: IBM
   labels:
@@ -36,8 +36,8 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: Represents a deployment of the IBM CSI Spectrum Scale driver.
-      displayName: IBM CSI Spectrum Scale Driver
+    - description: Represents a deployment of the IBM Spectrum Scale CSI driver.
+      displayName: IBM Spectrum Scale CSI Driver
       kind: CSIScaleOperator
       name: csiscaleoperators.csi.ibm.com
       resources:
@@ -533,7 +533,7 @@ spec:
   labels:
     operator: ibm-spectrum-scale-csi-operator
   links:
-  - name: IBM CSI Spectrum Scale Operator Documentation
+  - name: IBM Spectrum Scale CSI Operator Documentation
     url: https://ibm-spectrum-scale-csi-operator.readthedocs.io/en/latest/
   - name: CSI Developer Documentation
     url: https://kubernetes-csi.github.io/docs/


### PR DESCRIPTION
I don't think we  should merge this, because the changes should be in the `1.0.1` path for the files, and we should auto generate those...  

But I wanted  to at least create this PR as a placeholder for the changes we should make in this yaml files. 